### PR TITLE
Fix `numpy` array serialization issue when using JuliaCall

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 GeneralizedGenerated = "6b9d7cbe-bcb9-11e9-073f-15a7a543e2eb"
 Hwloc = "0e44f5e4-bd66-52a0-8798-143a42290a1d"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 

--- a/examples/example.jl
+++ b/examples/example.jl
@@ -3,10 +3,11 @@ using DataFrames
 using EquivalentCircuits
 
 """
-Circuit identification is done with the `circuit_evolution` function. This function can take
-several keyword arguments, allowing users to tune the circuit identification if necessary.
-These can be found in the function documentation. The measurements and frequencies should
-be provided either as a CSV file, or as arrays.
+Circuit identification is done with the `circuit_evolution` function. This
+function can take several keyword arguments, allowing users to tune the
+circuit identification if necessary. These can be found in the function
+documentation. The measurements and frequencies should be provided either
+as a CSV file, or as arrays. Here are two examples:
 """
 # Example 1: Input is CSV file with as columns: Re(Z), Im(Z), frequencies measurements
 circuit = circuit_evolution("example_measurements.csv")
@@ -18,13 +19,22 @@ freq = data[:, 3]
 @time circuit = circuit_evolution(Z, freq)
 
 """
-When the equivalent circuit to be used is known, its parameters can be fit using the
-`parameteroptimisation` function.
+When the equivalent circuit to be used is known, its parameters can be fit
+using the `parameteroptimisation` function.
 """
 p = parameteroptimisation("[[C1,R2]-R3,P4]", Z, freq)
 
 """
-If you want to generate multiple candidate circuits, you can use the `circuit_evolution_batch`
-function. This function is parallelised on all available cores.
+If you want to generate multiple candidate circuits, you can use the
+`circuit_evolution_batch` function. This function is parallelised on all
+available cores.
 """
-circuits = circuit_evolution_batch(Z, freq; generations=30, population_size=100, iters=6);
+circuits = circuit_evolution_batch(
+    Z,
+    freq;
+    generations=5,
+    population_size=5,
+    iters=6,
+    convergence_threshold=1e10,
+    quiet=true,
+);

--- a/src/CircuitEvolution.jl
+++ b/src/CircuitEvolution.jl
@@ -369,10 +369,13 @@ function circuit_evolution_batch(
     bounds=nothing,
     numprocs=num_physical_cores(),
     iters,
+    quiet=false,
 )
     # Set up workers
     _workers = addprocs(min(numprocs, iters))
     import_module_on_workers(_workers)
+    # Optionally disable logging (useful when calling from Python)
+    quiet && disable_logging_distributed(Logging.Warn, _workers)
 
     # Run the circuit evolution in parallel on all workers
     @info "Starting circuit evolution on $(length(_workers)) workers"

--- a/src/CircuitEvolution.jl
+++ b/src/CircuitEvolution.jl
@@ -376,6 +376,7 @@ function circuit_evolution_batch(
     import_module_on_workers(_workers)
     # Optionally disable logging (useful when calling from Python)
     quiet && disable_logging_distributed(Logging.Warn, _workers)
+    quiet && disable_logging(Logging.Warn)
 
     # Re-convert inputs to arrays until JuliaPy/PythonCall.jl/issues/454 is resolved
     measurements = Array(measurements)

--- a/src/CircuitEvolution.jl
+++ b/src/CircuitEvolution.jl
@@ -377,6 +377,10 @@ function circuit_evolution_batch(
     # Optionally disable logging (useful when calling from Python)
     quiet && disable_logging_distributed(Logging.Warn, _workers)
 
+    # Re-convert inputs to arrays until JuliaPy/PythonCall.jl/issues/454 is resolved
+    measurements = Array(measurements)
+    frequencies = Array(frequencies)
+
     # Run the circuit evolution in parallel on all workers
     @info "Starting circuit evolution on $(length(_workers)) workers"
     results = pmap(

--- a/src/CircuitEvolution.jl
+++ b/src/CircuitEvolution.jl
@@ -190,7 +190,8 @@ julia> circuit_evolution(measurements, frequencies , generations= 15, terminals 
 [R1,C2]-[C3,R4]-R5
 ```
 """
-function circuit_evolution(measurements,frequencies;generations::Real=10,population_size=30,terminals = "RCLP",head=8,cutoff=0.8,initial_population=nothing,convergence_threshold=5e-4,bounds=nothing)
+function circuit_evolution(measurements,frequencies;generations::Real=10,population_size=30,terminals = "RCLP",head=8,cutoff=0.8,initial_population=nothing,convergence_threshold=5e-4,bounds=nothing,quiet=false)
+    quiet && disable_logging(Logging.Warn)
     parameter_bounds = Dict('R'=>[0,1.0e9],'C'=>[0,10],'L'=>[0,5],'P'=>[[0,0],[1.0e9,1]],'W'=>[0,1.0e9],'+'=>[0,0],'-'=>[0,0])
     if typeof(bounds) == Dict{Char, Vector}
         for key in keys(bounds)

--- a/src/EquivalentCircuits.jl
+++ b/src/EquivalentCircuits.jl
@@ -21,7 +21,6 @@ module EquivalentCircuits
     include("RedundancyTesting.jl")
     include("Miscellaneous.jl")
     include("CircuitEvolution.jl")
-    include("MAP_elites.jl")
-
+    # include("MAP_elites.jl")
 
 end

--- a/src/Miscellaneous.jl
+++ b/src/Miscellaneous.jl
@@ -1,3 +1,4 @@
+using Logging
 using Distributed
 
 # circuitstring conversion to and from impedance.py
@@ -114,5 +115,13 @@ end
 function import_module_on_workers(procs)
     @everywhere procs begin
         Base.MainInclude.eval(:(using EquivalentCircuits))
+    end
+end
+
+
+function disable_logging_distributed(level::Logging.LogLevel, procs::Vector{Int})
+    @everywhere procs begin
+        Base.MainInclude.eval(:(using Logging))
+        disable_logging($level)  # Use the variable level here
     end
 end


### PR DESCRIPTION
Hi @MaximeVH. This PR does the following:

- Adds `quiet` argument to both `circuit_evolution` and `circuit_evolution_batch` to optionally disable Logging (false by default)
- Force converts `measurements` and `frequencies` to `Array` to fix a serialization issue when called from Python (Python passes `numpy` array, and Julia can't serialize them, which is required for distributed jobs, so it only affects `circuit_evolution_batch`)

Please see JuliaPy/PythonCall.jl/issues/454 for details.

This PR is ready, feel free to merge when you're done reviewing.

(I also commented the MAP_elites.jl import for now as it causes lots of re-import warnings. We can include it once we've tested the new algorithm to make it the new default)